### PR TITLE
ignore the source-0 folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+
+# Ignore source-0 (codeny.io?)
+/source-0/*


### PR DESCRIPTION
This addition to `.gitignore` ignore the `source-0` folder.